### PR TITLE
[Shader Rework] Implementing Shader Type Traits

### DIFF
--- a/Rasterizer/include/Rendering/ShaderTypeTraits.h
+++ b/Rasterizer/include/Rendering/ShaderTypeTraits.h
@@ -1,0 +1,206 @@
+#pragma once
+
+#include <glm/glm.hpp>
+
+#include "Rendering/EShaderUniformType.h"
+
+namespace Rendering
+{
+	template <typename T>
+	struct ShaderTypeTraits
+	{
+		static constexpr EShaderDataType Type = EShaderDataType::INT;
+		static constexpr uint8_t TypeCount = 0;
+
+		static void WriteToBuffer(const T& p_value, float* p_buffer)
+		{
+			static_assert(sizeof(T) == 0, "No specialization for this type.");
+		}
+
+		static T ReadFromBuffer(const float* p_buffer)
+		{
+			static_assert(sizeof(T) == 0, "No specialization for this type.");
+			return T{};
+		}
+	};
+
+	template <>
+	struct ShaderTypeTraits<int>
+	{
+		static constexpr EShaderDataType Type = EShaderDataType::INT;
+		static constexpr uint8_t TypeCount = 1;
+
+		static void WriteToBuffer(const int& p_value, float* p_buffer)
+		{
+			p_buffer[0] = static_cast<float>(p_value);
+		}
+
+		static int ReadFromBuffer(const float* p_buffer)
+		{
+			return static_cast<int>(p_buffer[0]);
+		}
+	};
+
+	template <>
+	struct ShaderTypeTraits<float>
+	{
+		static constexpr EShaderDataType Type = EShaderDataType::FLOAT;
+		static constexpr uint8_t TypeCount = 1;
+
+		static void WriteToBuffer(const float& p_value, float* p_buffer)
+		{
+			p_buffer[0] = p_value;
+		}
+
+		static float ReadFromBuffer(const float* p_buffer)
+		{
+			return p_buffer[0];
+		}
+	};
+
+	template <>
+	struct ShaderTypeTraits<glm::vec2>
+	{
+		static constexpr EShaderDataType Type = EShaderDataType::VEC2;
+		static constexpr uint8_t TypeCount = 2;
+
+		static void WriteToBuffer(const glm::vec2& p_value, float* p_buffer)
+		{
+			p_buffer[0] = p_value.x;
+			p_buffer[1] = p_value.y;
+		}
+
+		static glm::vec2 ReadFromBuffer(const float* p_buffer)
+		{
+			return glm::vec2(p_buffer[0], p_buffer[1]);
+		}
+	};
+
+	template <>
+	struct ShaderTypeTraits<glm::vec3>
+	{
+		static constexpr EShaderDataType Type = EShaderDataType::VEC3;
+		static constexpr uint8_t TypeCount = 3;
+
+		static void WriteToBuffer(const glm::vec3& p_value, float* p_buffer)
+		{
+			p_buffer[0] = p_value.x;
+			p_buffer[1] = p_value.y;
+			p_buffer[2] = p_value.z;
+		}
+
+		static glm::vec3 ReadFromBuffer(const float* p_buffer)
+		{
+			return glm::vec3(p_buffer[0], p_buffer[1], p_buffer[2]);
+		}
+	};
+
+	template <>
+	struct ShaderTypeTraits<glm::vec4>
+	{
+		static constexpr EShaderDataType Type = EShaderDataType::VEC4;
+		static constexpr uint8_t TypeCount = 4;
+
+		static void WriteToBuffer(const glm::vec4& p_value, float* p_buffer)
+		{
+			p_buffer[0] = p_value.x;
+			p_buffer[1] = p_value.y;
+			p_buffer[2] = p_value.z;
+			p_buffer[3] = p_value.w;
+		}
+
+		static glm::vec4 ReadFromBuffer(const float* p_buffer)
+		{
+			return glm::vec4(p_buffer[0], p_buffer[1], p_buffer[2], p_buffer[3]);
+		}
+	};
+
+	template <>
+	struct ShaderTypeTraits<glm::mat2>
+	{
+		static constexpr EShaderDataType Type = EShaderDataType::MAT2;
+		static constexpr uint8_t TypeCount = 4;
+
+		static void WriteToBuffer(const glm::mat2& p_value, float* p_buffer)
+		{
+			p_buffer[0] = p_value[0][0];
+			p_buffer[1] = p_value[0][1];
+			p_buffer[2] = p_value[1][0];
+			p_buffer[3] = p_value[1][1];
+		}
+
+		static glm::mat2 ReadFromBuffer(const float* p_buffer)
+		{
+			return glm::mat2(
+				p_buffer[0], p_buffer[1],
+				p_buffer[2], p_buffer[3]
+			);
+		}
+	};
+
+	template <>
+	struct ShaderTypeTraits<glm::mat3>
+	{
+		static constexpr EShaderDataType Type = EShaderDataType::MAT3;
+		static constexpr uint8_t TypeCount = 9;
+
+		static void WriteToBuffer(const glm::mat3& p_value, float* p_buffer)
+		{
+			p_buffer[0] = p_value[0][0];
+			p_buffer[1] = p_value[0][1];
+			p_buffer[2] = p_value[0][2];
+			p_buffer[3] = p_value[1][0];
+			p_buffer[4] = p_value[1][1];
+			p_buffer[5] = p_value[1][2];
+			p_buffer[6] = p_value[2][0];
+			p_buffer[7] = p_value[2][1];
+			p_buffer[8] = p_value[2][2];
+		}
+
+		static glm::mat3 ReadFromBuffer(const float* p_buffer)
+		{
+			return glm::mat3(
+				p_buffer[0], p_buffer[1], p_buffer[2],
+				p_buffer[3], p_buffer[4], p_buffer[5],
+				p_buffer[6], p_buffer[7], p_buffer[8]
+			);
+		}
+	};
+
+	template <>
+	struct ShaderTypeTraits<glm::mat4>
+	{
+		static constexpr EShaderDataType Type = EShaderDataType::MAT4;
+		static constexpr uint8_t TypeCount = 16;
+
+		static void WriteToBuffer(const glm::mat4& p_value, float* p_buffer)
+		{
+			p_buffer[0] = p_value[0][0];
+			p_buffer[1] = p_value[0][1];
+			p_buffer[2] = p_value[0][2];
+			p_buffer[3] = p_value[0][3];
+			p_buffer[4] = p_value[1][0];
+			p_buffer[5] = p_value[1][1];
+			p_buffer[6] = p_value[1][2];
+			p_buffer[7] = p_value[1][3];
+			p_buffer[8] = p_value[2][0];
+			p_buffer[9] = p_value[2][1];
+			p_buffer[10] = p_value[2][2];
+			p_buffer[11] = p_value[2][3];
+			p_buffer[12] = p_value[3][0];
+			p_buffer[13] = p_value[3][1];
+			p_buffer[14] = p_value[3][2];
+			p_buffer[15] = p_value[3][3];
+		}
+
+		static glm::mat4 ReadFromBuffer(const float* p_buffer)
+		{
+			return glm::mat4(
+				p_buffer[0], p_buffer[1], p_buffer[2], p_buffer[3],
+				p_buffer[4], p_buffer[5], p_buffer[6], p_buffer[7],
+				p_buffer[8], p_buffer[9], p_buffer[10], p_buffer[11],
+				p_buffer[12], p_buffer[13], p_buffer[14], p_buffer[15]
+			);
+		}
+	};
+}

--- a/Rasterizer/src/Rendering/DefaultShader.cpp
+++ b/Rasterizer/src/Rendering/DefaultShader.cpp
@@ -2,26 +2,26 @@
 
 glm::vec4 Rendering::DefaultShader::VertexPass(const Geometry::Vertex& p_vertex)
 {
-	const glm::mat4 u_Model      = GetUniformAsMat4("u_Model");
-	const glm::mat4 u_View       = GetUniformAsMat4("u_View");
-	const glm::mat4 u_Projection = GetUniformAsMat4("u_Projection");
+	const glm::mat4 u_Model      = GetUniformAs<glm::mat4>("u_Model");
+	const glm::mat4 u_View       = GetUniformAs<glm::mat4>("u_View");
+	const glm::mat4 u_Projection = GetUniformAs<glm::mat4>("u_Projection");
 
 	glm::vec3 fragPos = glm::vec3(u_Model * glm::vec4(p_vertex.position, 1.0));
-	SetFlatVec3("v_FragPos", fragPos);
+	SetFlat<glm::vec3>("v_FragPos", fragPos);
 
 	glm::vec3 normal = glm::mat3(glm::transpose(glm::inverse(u_Model))) * p_vertex.normal;
-	SetVaryingVec3("v_Normal", normal);
+	SetVarying<glm::vec3>("v_Normal", normal);
 
 	glm::vec2 texCoords = p_vertex.textCoords;
-	SetVaryingVec2("v_TextCoords", texCoords);
+	SetVarying<glm::vec2>("v_TextCoords", texCoords);
 
 	return  u_Projection * u_View * glm::vec4(fragPos, 1.0);
 }
 
 Data::Color Rendering::DefaultShader::FragmentPass()
 {
-	glm::vec3 normal     = glm::normalize(GetVaryingAsVec3("v_Normal"));
-	glm::vec2 textCoords = GetVaryingAsVec2("v_TextCoords");
+	glm::vec3 normal     = glm::normalize(GetVaryingAs<glm::vec3>("v_Normal"));
+	glm::vec2 textCoords = GetVaryingAs<glm::vec2>("v_TextCoords");
 
 	//return glm::vec4(((normal * 0.5f) + 0.5f), 1.0f);
 

--- a/Rasterizer/src/Rendering/Rasterizer.cpp
+++ b/Rasterizer/src/Rendering/Rasterizer.cpp
@@ -131,9 +131,9 @@ void Rendering::Rasterizer::RasterizeTriangle(Settings::EDrawMode p_drawMode, co
 		{
 			std::array<glm::vec4, 3> clippedVertices{ currentPoly.Vertices[0], currentPoly.Vertices[i + 1], currentPoly.Vertices[i + 2] };
 
-			p_shader.SetVaryingVec2("v_TextCoords", currentPoly.TextCoords[0], 0);
-			p_shader.SetVaryingVec2("v_TextCoords", currentPoly.TextCoords[i + 1], 1);
-			p_shader.SetVaryingVec2("v_TextCoords", currentPoly.TextCoords[i + 2], 2);
+			p_shader.SetVarying<glm::vec2>("v_TextCoords", currentPoly.TextCoords[0], 0);
+			p_shader.SetVarying<glm::vec2>("v_TextCoords", currentPoly.TextCoords[i + 1], 1);
+			p_shader.SetVarying<glm::vec2>("v_TextCoords", currentPoly.TextCoords[i + 2], 2);
 
 			TransformAndRasterizeVertices(p_drawMode, clippedVertices, p_shader);
 		}


### PR DESCRIPTION
# Rework Shader Data Handling Using Type Traits

## Summary
This PR introduces a **type‐traits** mechanism for our shader data (`Uniforms`, `Flats`, and `Varyings`) to eliminate repetitive “Set/Get” methods for each supported type. Instead, we define a central `ShaderTypeTraits<T>` struct (with partial specializations for `int`, `float`, `glm::vec2`, etc.) that knows:
- **How many floats** each type uses (`TypeCount`)
- **How to write/read** the type to/from a float array (`WriteToBuffer` / `ReadFromBuffer`)

## Changes
1. **Added `ShaderTypeTraits` in a `detail` namespace**:
   - Specializations for `int`, `float`, `glm::vec2`, `glm::vec3`, `glm::vec4`, `glm::mat2`, `glm::mat3`, and `glm::mat4`.
   - Each trait includes a `static constexpr EShaderDataType Type`, a `static constexpr int TypeCount`, and `WriteToBuffer` / `ReadFromBuffer` methods.

2. **Replaced multiple “SetUniformFloat/Vec3/etc.” and “GetUniformAsFloat/Vec3/etc.”** with templated functions:
   - `SetUniform<T>(...)` and `GetUniformAs<T>(...)`
   - Similar methods for `SetFlat`, `GetFlatAs`, `SetVarying`, and `GetVaryingAs`.

_Intentionally preserving the old “Set/Get” methods (e.g., SetVaryingFloat, SetVaryingVec2, etc.) alongside the new templated approach. The goal is to compare both versions and gather more performance data. I will remove the old methods once the new templated approach will be fully validated._