### PR TITLE
Texture Coordinates Derivatives

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A CPU-based software renderer designed to explore low-level rendering techniques
 - Line Rasterization
 - Texture Mapping
 - Clipping
-- Mipmapping
+- Mipmapping based on texture derivates
 - MSAA
 - Vertex pass
 - Fragment pass
@@ -27,6 +27,10 @@ A CPU-based software renderer designed to explore low-level rendering techniques
 - OBJ Parsing  
  
 ![shadows](https://github.com/user-attachments/assets/1a9ad66d-19be-4d34-bf33-b411a7c03dc8)
+
+| Mipmapping | Texture Coordinates Derivates | Shadow Mapping |
+| :------------------------: | :------------------------: | :------------------------: |
+| ![Texture Sampling Technique](https://github.com/user-attachments/assets/50b01b40-f404-4209-8347-0063fbda3c9d) | ![Mipmap Level Detail](https://github.com/user-attachments/assets/5464680e-f90a-4d3c-80df-5717f84f0375) | ![Shadow Mapping](https://github.com/user-attachments/assets/c6dcfb1d-b6bd-4d34-8e0b-25655653ace8) |
 
 # AmberGL API
 An OpenGL-inspired API that encapsulates its own Rendering State and manages internal buffers to provide a streamlined interface for Drawing, handling Buffers, and processing Shaders.

--- a/Sources/AmberRenderer/AmberGL/include/AmberGL/Maths/Uttils/MathUtils.h
+++ b/Sources/AmberRenderer/AmberGL/include/AmberGL/Maths/Uttils/MathUtils.h
@@ -1,0 +1,6 @@
+#pragma once
+
+namespace MathUtils
+{
+	float InterpolateBilinear(const float topLeft, const float topRight, const float bottomLeft, const float bottomRight, float xFactor, float yFactor);
+}

--- a/Sources/AmberRenderer/AmberGL/include/AmberGL/SoftwareRenderer/Programs/AProgram.h
+++ b/Sources/AmberRenderer/AmberGL/include/AmberGL/SoftwareRenderer/Programs/AProgram.h
@@ -113,11 +113,13 @@ namespace AmberGL::SoftwareRenderer::Programs
 			return ShaderTypeTraits<T>::ReadFromBuffer(it->second.Data[p_vertexIndex]);
 		}
 
+		void SetDerivative(glm::vec2 p_dfdx, glm::vec2 p_dfdy);
+
 		glm::vec4 Texture(const std::string_view p_samplerName, const glm::vec2& p_texCoords) const;
 
 		std::unordered_map<std::string_view, ShaderVarying>& GetVaryings();
 		uint8_t GetTypeCount(EShaderDataType p_type) const;
-		
+
 	protected:
 		virtual glm::vec4 VertexPass(const Geometry::Vertex& p_vertex) = 0;
 		virtual glm::vec4 FragmentPass() = 0;
@@ -127,6 +129,9 @@ namespace AmberGL::SoftwareRenderer::Programs
 	protected:
 		uint8_t m_vertexIndex = 0;
 		float m_interpolatedReciprocal = 1.0f;
+
+		glm::vec2 m_dfdx;
+		glm::vec2 m_dfdy;
 
 	private:
 		std::unordered_map<std::string_view, ShaderData> m_uniforms;

--- a/Sources/AmberRenderer/AmberGL/include/AmberGL/SoftwareRenderer/Programs/AProgram.h
+++ b/Sources/AmberRenderer/AmberGL/include/AmberGL/SoftwareRenderer/Programs/AProgram.h
@@ -113,7 +113,7 @@ namespace AmberGL::SoftwareRenderer::Programs
 			return ShaderTypeTraits<T>::ReadFromBuffer(it->second.Data[p_vertexIndex]);
 		}
 
-		void SetDerivative(glm::vec2 p_dfdx, glm::vec2 p_dfdy);
+		void SetDerivatives(glm::vec2 p_dfdx, glm::vec2 p_dfdy);
 
 		glm::vec4 Texture(const std::string_view p_samplerName, const glm::vec2& p_texCoords) const;
 

--- a/Sources/AmberRenderer/AmberGL/include/AmberGL/SoftwareRenderer/TextureSampler.h
+++ b/Sources/AmberRenderer/AmberGL/include/AmberGL/SoftwareRenderer/TextureSampler.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <array>
+#include <glm/glm.hpp>
+
+#include "RenderObject/TextureObject.h"
+
+namespace AmberGL::SoftwareRenderer
+{
+	class TextureSampler
+	{
+	public:
+		TextureSampler() = default;
+		~TextureSampler() = default;
+
+		static glm::vec4 Sample(const RenderObject::TextureObject* p_textureObject, const glm::vec2& p_texCoords, const std::array<glm::vec2, 2>& p_texCoordsDerivatives);
+		static uint8_t ComputeMipmapLevel(const RenderObject::TextureObject* p_textureObject, const glm::vec2& p_dfdx, const glm::vec2& p_dfdy);
+	private:
+		static float ApplyWrapMode(float p_coord, uint8_t p_wrapMode);
+
+		static glm::vec4 SampleNearest(const uint8_t* p_data, uint32_t p_width, uint32_t p_height, float p_x, float p_y);
+		static glm::vec4 SampleBilinear(const uint8_t* p_data, uint32_t p_width, glm::uint32_t p_height, float p_x, float p_y);
+	};
+}

--- a/Sources/AmberRenderer/AmberGL/src/AmberGL/SoftwareRenderer/Maths/Utils/MathUtils.cpp
+++ b/Sources/AmberRenderer/AmberGL/src/AmberGL/SoftwareRenderer/Maths/Utils/MathUtils.cpp
@@ -1,0 +1,9 @@
+#include "AmberGL/Maths/Uttils/MathUtils.h"
+
+float MathUtils::InterpolateBilinear(const float topLeft, const float topRight, const float bottomLeft, const float bottomRight, float xFactor, float yFactor)
+{
+	return (1.0f - xFactor) * (1.0f - yFactor) * topLeft
+		+ xFactor * (1.0f - yFactor) * topRight
+		+ (1.0f - xFactor) * yFactor * bottomLeft
+		+ xFactor * yFactor * bottomRight;
+}

--- a/Sources/AmberRenderer/AmberGL/src/AmberGL/SoftwareRenderer/Programs/AProgram.cpp
+++ b/Sources/AmberRenderer/AmberGL/src/AmberGL/SoftwareRenderer/Programs/AProgram.cpp
@@ -44,7 +44,7 @@ glm::vec4 AmberGL::SoftwareRenderer::Programs::AProgram::ProcessFragment()
 	return FragmentPass();
 }
 
-void AmberGL::SoftwareRenderer::Programs::AProgram::SetDerivative(glm::vec2 p_dfdx, glm::vec2 p_dfdy)
+void AmberGL::SoftwareRenderer::Programs::AProgram::SetDerivatives(glm::vec2 p_dfdx, glm::vec2 p_dfdy)
 {
 	m_dfdx = p_dfdx;
 	m_dfdy = p_dfdy;

--- a/Sources/AmberRenderer/AmberGL/src/AmberGL/SoftwareRenderer/TextureSampler.cpp
+++ b/Sources/AmberRenderer/AmberGL/src/AmberGL/SoftwareRenderer/TextureSampler.cpp
@@ -1,0 +1,138 @@
+﻿#include "AmberGL/SoftwareRenderer/TextureSampler.h"
+
+#include <algorithm>
+
+#include "AmberGL/Maths/Uttils/MathUtils.h"
+#include "AmberGL/SoftwareRenderer/Defines.h"
+
+glm::vec4 AmberGL::SoftwareRenderer::TextureSampler::Sample(const RenderObject::TextureObject* p_textureObject, const glm::vec2& p_texCoords, const std::array<glm::vec2, 2>& p_texCoordsDerivatives)
+{
+	if (p_textureObject == nullptr)
+		return glm::vec4(1.0f);
+
+	uint32_t width = p_textureObject->Width;
+	uint32_t height = p_textureObject->Height;
+
+	bool hasMipmaps = p_textureObject->Mipmaps != nullptr;
+	uint8_t currentLOD = 0;
+
+	if (hasMipmaps)
+	{
+		currentLOD = ComputeMipmapLevel(p_textureObject, p_texCoordsDerivatives[0], p_texCoordsDerivatives[1]);
+	}
+
+	if (hasMipmaps && currentLOD > 0)
+	{
+		width = std::max(1u, width >> currentLOD);
+		height = std::max(1u, height >> currentLOD);
+	}
+
+	float uvX = std::abs(p_texCoords.x);
+	float uvY = std::abs(p_texCoords.y);
+
+	uvX = ApplyWrapMode(uvX, p_textureObject->WrapS);
+	uvY = ApplyWrapMode(uvY, p_textureObject->WrapT);
+
+	uvX = uvX * (static_cast<float>(width) - 0.5f);
+	uvY = uvY * (static_cast<float>(height) - 0.5f);
+
+	uint8_t filter = currentLOD == 0 ? p_textureObject->MagFilter : p_textureObject->MinFilter;
+
+	const uint8_t* data = hasMipmaps && currentLOD > 0 ? p_textureObject->Mipmaps[currentLOD] : p_textureObject->Data8;
+
+	if (filter == AGL_LINEAR)
+	{
+		return SampleBilinear(data, width, height, uvX, uvY);
+	}
+
+	return SampleNearest(data, width, height, uvX, uvY);
+}
+
+uint8_t AmberGL::SoftwareRenderer::TextureSampler::ComputeMipmapLevel(const RenderObject::TextureObject* p_textureObject, const glm::vec2& p_dfdx, const glm::vec2& p_dfdy)
+{
+	if (!p_textureObject || !p_textureObject->Mipmaps)
+		return 0;
+
+	glm::vec2 textureSize(p_textureObject->Width, p_textureObject->Height);
+
+	glm::vec2 tcDx = p_dfdx * textureSize;
+	glm::vec2 tcDy = p_dfdy * textureSize;
+
+	float det = std::abs(tcDx.x * tcDy.y - tcDx.y * tcDy.x);
+
+	float texelArea = 1.0f / det;
+
+	bool magnification = texelArea >= 1.0f;
+
+	if (magnification)
+		return 0;
+	
+	uint8_t mipmapCurrentLevel = std::ceil(-std::log2(std::min(1.0f, texelArea)) / 2.0f);
+
+	uint8_t mipmapMaxLevel = 1 + static_cast<int>(std::floor(std::log2(std::max(p_textureObject->Width, p_textureObject->Height))));
+
+	return std::min<uint8_t>(mipmapCurrentLevel, mipmapMaxLevel - 1);
+}
+
+float AmberGL::SoftwareRenderer::TextureSampler::ApplyWrapMode(float p_coord, uint8_t p_wrapMode)
+{
+	if (p_wrapMode == AGL_CLAMP)
+	{
+		return glm::clamp(p_coord, 0.0f, 1.0f);
+	}
+
+	if (p_wrapMode == AGL_REPEAT)
+	{
+		return glm::mod(p_coord, 1.0f);
+	}
+
+	return glm::clamp(p_coord, 0.0f, 1.0f);
+}
+
+glm::vec4 AmberGL::SoftwareRenderer::TextureSampler::SampleNearest(const uint8_t* p_data, uint32_t p_width, uint32_t p_height, float p_x, float p_y)
+{
+	int x = static_cast<int>(std::round(p_x));
+	int y = static_cast<int>(std::round(p_y));
+
+	x = glm::clamp(x, 0, static_cast<int>(p_width) - 1);
+	y = glm::clamp(y, 0, static_cast<int>(p_height) - 1);
+
+	const uint32_t index = (y * p_width + x) * 4;
+
+	return glm::vec4(
+		p_data[index] / 255.0f,
+		p_data[index + 1] / 255.0f,
+		p_data[index + 2] / 255.0f,
+		p_data[index + 3] / 255.0f
+	);
+}
+
+glm::vec4 AmberGL::SoftwareRenderer::TextureSampler::SampleBilinear(const uint8_t* p_data, uint32_t p_width, glm::uint32_t p_height, float p_x, float p_y)
+{
+	int x0 = static_cast<int>(std::floor(p_x));
+	int y0 = static_cast<int>(std::floor(p_y));
+	int x1 = std::min(x0 + 1, static_cast<int>(p_width) - 1);
+	int y1 = std::min(y0 + 1, static_cast<int>(p_height) - 1);
+
+	float fracX = p_x - x0;
+	float fracY = p_y - y0;
+
+	uint32_t idx00 = (y0 * p_width + x0) * 4;
+	uint32_t idx01 = (y1 * p_width + x0) * 4;
+	uint32_t idx10 = (y0 * p_width + x1) * 4;
+	uint32_t idx11 = (y1 * p_width + x1) * 4;
+
+	glm::vec4 color;
+
+	for (int i = 0; i < 4; i++)
+	{
+		float c00 = p_data[idx00 + i] / 255.0f;
+		float c01 = p_data[idx01 + i] / 255.0f;
+		float c10 = p_data[idx10 + i] / 255.0f;
+		float c11 = p_data[idx11 + i] / 255.0f;
+
+		color[i] = MathUtils::InterpolateBilinear(c00, c10, c01, c11, fracX, fracY);
+	}
+
+	return color;
+}


### PR DESCRIPTION
## Description

Implemented texture coordinates derivatives to accurately compute the current mipmap level mimicking GPU texture sampling techniques.

## Related Issues
#8 

## Screenshots
![Screenshot 2025-04-08 233927](https://github.com/user-attachments/assets/50b01b40-f404-4209-8347-0063fbda3c9d)
![Screenshot 2025-04-08 234119](https://github.com/user-attachments/assets/5464680e-f90a-4d3c-80df-5717f84f0375)
