### PR TITLE
Reworked line and point rasterization and Added depth func

### DIFF
--- a/Sources/AmberRenderer/AmberEditor/src/AmberEditor/Rendering/Renderer.cpp
+++ b/Sources/AmberRenderer/AmberEditor/src/AmberEditor/Rendering/Renderer.cpp
@@ -148,7 +148,6 @@ void AmberEditor::Rendering::Renderer::ApplyStateMask(uint8_t p_mask)
 {
 	if (p_mask != m_state)
 	{
-
 		if ((p_mask & 0x01) != (m_state & 0x01)) m_driver.SetDepthWriting(p_mask & 0x01);
 		if ((p_mask & 0x02) != (m_state & 0x02)) m_driver.SetCapability(Settings::ERenderingCapability::DEPTH_TEST, p_mask & 0x02);
 		if ((p_mask & 0x04) != (m_state & 0x04)) m_driver.SetCapability(Settings::ERenderingCapability::CULL_FACE, p_mask & 0x04);

--- a/Sources/AmberRenderer/AmberGL/include/AmberGL/Geometry/Line.h
+++ b/Sources/AmberRenderer/AmberGL/include/AmberGL/Geometry/Line.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <array>
+
+#include <glm/glm.hpp>
+
+//TODO: Should inherit from Primitive
+namespace AmberGL::Geometry
+{
+	struct Line
+	{
+		std::array<glm::vec4, 2> ScreenSpaceCoordinates;
+		float Lenght;
+
+		Line(const std::array<glm::vec4, 2>& p_screenSpaceCoordinates) : ScreenSpaceCoordinates(p_screenSpaceCoordinates)
+		{
+			glm::vec2 delta = ScreenSpaceCoordinates[0] - ScreenSpaceCoordinates[1];
+			Lenght = std::sqrt(delta.x * delta.x + delta.y * delta.y);
+		}
+	};
+}

--- a/Sources/AmberRenderer/AmberGL/include/AmberGL/Geometry/Plane.h
+++ b/Sources/AmberRenderer/AmberGL/include/AmberGL/Geometry/Plane.h
@@ -1,6 +1,10 @@
 #pragma once
 
-#include <glm/vec3.hpp>
+#define GLM_ENABLE_EXPERIMENTAL
+#include <glm/gtx/compatibility.hpp>
+#include <glm/glm.hpp>
+
+#include "Polygon.h"
 
 namespace AmberGL::Geometry
 {
@@ -8,5 +12,12 @@ namespace AmberGL::Geometry
 	{
 		glm::vec3 Normal;
 		float Distance;
+
+		void ClipTriangle(Polygon& p_polygon) const;
+		void ClipLine(Polygon& p_polygon) const;
+		void ClipPoint(Polygon& p_polygon) const;
+
+		float SignedDistance(const glm::vec4& p_point) const;
+		bool IsInFront(const glm::vec4& p_point) const;
 	};
 }

--- a/Sources/AmberRenderer/AmberGL/include/AmberGL/Geometry/Point.h
+++ b/Sources/AmberRenderer/AmberGL/include/AmberGL/Geometry/Point.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <glm/glm.hpp>
+
+//TODO: Should inherit from Primitive
+namespace AmberGL::Geometry
+{
+	struct Point
+	{
+		glm::vec4 ScreenSpaceCoordinate;
+
+		Point() = default;
+
+		Point(const glm::vec4& p_screenSpaceCoordinate) : ScreenSpaceCoordinate(p_screenSpaceCoordinate)
+		{
+		}
+	};
+}

--- a/Sources/AmberRenderer/AmberGL/include/AmberGL/Geometry/Polygon.h
+++ b/Sources/AmberRenderer/AmberGL/include/AmberGL/Geometry/Polygon.h
@@ -13,8 +13,8 @@ namespace AmberGL::Geometry
 	struct Polygon
 	{
 		std::array<glm::vec4, MAX_POLY_COUNT> Vertices;
-		std::array <glm::vec2, MAX_POLY_COUNT> TexCoords;
-		std::array <glm::vec3, MAX_POLY_COUNT> Normals;
+		std::array<glm::vec2, MAX_POLY_COUNT> TexCoords;
+		std::array<glm::vec3, MAX_POLY_COUNT> Normals;
 
 		float Varyings[MAX_POLY_COUNT][16];
 		uint8_t VaryingsDataSize;

--- a/Sources/AmberRenderer/AmberGL/include/AmberGL/Geometry/Triangle.h
+++ b/Sources/AmberRenderer/AmberGL/include/AmberGL/Geometry/Triangle.h
@@ -1,6 +1,8 @@
 #pragma once
 
-#include <glm/vec3.hpp>
+#include <array>
+
+#include <glm/glm.hpp>
 
 #include "AmberGL/Geometry/BoundingBox2D.h"
 
@@ -20,6 +22,8 @@ namespace AmberGL::Geometry
 		float ComputeEdge(const glm::vec2& p_vertex0, const glm::vec2& p_vertex1, const glm::vec2& p_vertex2) const;
 
 		float ComputeArea() const;
+
+		float ComputeMaxDepthSlope(const std::array<glm::vec4, 3>& p_vertices) const;
 
 	private:
 		glm::vec2 m_vertex0;

--- a/Sources/AmberRenderer/AmberGL/include/AmberGL/SoftwareRenderer/AmberGL.h
+++ b/Sources/AmberRenderer/AmberGL/include/AmberGL/SoftwareRenderer/AmberGL.h
@@ -5,14 +5,13 @@
 #include "AmberGL/API/Export.h"
 
 #include "AmberGL/SoftwareRenderer/Defines.h"
-#include "AmberGL/SoftwareRenderer/RenderObject/TextureObject.h"
 #include "AmberGL/SoftwareRenderer/Programs/AProgram.h"
+#include "AmberGL/SoftwareRenderer/RenderObject/TextureObject.h"
 
 namespace AmberGL
 {
 	API_AMBERGL void Initialize(uint16_t p_rasterizationBufferWidth, uint16_t p_rasterizationBufferHeight);
 	API_AMBERGL void Terminate();
-
 	API_AMBERGL void WindowHint(uint8_t p_name, uint8_t p_value);
 
 	API_AMBERGL void ClearColor(float p_red, float p_green, float p_blue, float p_alpha);
@@ -20,7 +19,11 @@ namespace AmberGL
 	API_AMBERGL void Viewport(uint16_t p_x, uint16_t p_y, uint16_t p_width, uint16_t p_height);
 	API_AMBERGL void DrawElements(uint8_t primitiveMode, uint32_t indexCount);
 	API_AMBERGL void DrawArrays(uint8_t primitiveMode, uint32_t first, uint32_t count);
+	API_AMBERGL void PointSize(float p_size);
+	API_AMBERGL void LineWidth(float p_width);
 	API_AMBERGL void DrawLine(const glm::vec3& p_point0, const glm::vec3& p_point1, const glm::vec4& p_color);
+	API_AMBERGL void DrawPoint(const glm::vec3& p_point0);
+	API_AMBERGL void DepthFunc(uint16_t p_func);
 
 	API_AMBERGL uint32_t CreateProgram();
 	API_AMBERGL void DeleteProgram(uint32_t p_program);

--- a/Sources/AmberRenderer/AmberGL/include/AmberGL/SoftwareRenderer/Defines.h
+++ b/Sources/AmberRenderer/AmberGL/include/AmberGL/SoftwareRenderer/Defines.h
@@ -1,5 +1,7 @@
 #pragma once
 
+//TODO: Convert #define constants to enum classes. Current approach mimics OpenGL API style but lacks type safety.
+
 // -----------------------------------------------------------------------------
 // PRIMITIVE TYPES
 // -----------------------------------------------------------------------------
@@ -85,6 +87,18 @@
 // TEXTURE UNIT
 // -----------------------------------------------------------------------------
 #define AGL_TEXTURE0 0
+
+// -----------------------------------------------------------------------------
+// DEPTH OPERAND
+// -----------------------------------------------------------------------------
+#define AGL_NEVER        0x0200
+#define AGL_LESS         0x0201
+#define AGL_EQUAL        0x0202
+#define AGL_LEQUAL       0x0203
+#define AGL_GREATER      0x0204
+#define AGL_NOTEQUAL     0x0205
+#define AGL_GEQUAL       0x0206
+#define AGL_ALWAYS       0x0207
 
 // -----------------------------------------------------------------------------
 // FRAMEBUFFER ATTACHMENTS

--- a/Sources/AmberRenderer/AmberGL/include/AmberGL/SoftwareRenderer/Programs/AProgram.h
+++ b/Sources/AmberRenderer/AmberGL/include/AmberGL/SoftwareRenderer/Programs/AProgram.h
@@ -39,6 +39,7 @@ namespace AmberGL::SoftwareRenderer::Programs
 		virtual glm::vec4 ProcessVertex(const Geometry::Vertex& p_vertex, uint8_t p_vertexID);
 
 		void ProcessInterpolation(const glm::vec3& p_barycentricCoords, float p_w0, float p_w1, float p_w2);
+		void ProcessPointInterpolation(float p_w0);
 
 		glm::vec4 ProcessFragment();
 

--- a/Sources/AmberRenderer/AmberGL/include/AmberGL/SoftwareRenderer/RenderObject/RenderContext.h
+++ b/Sources/AmberRenderer/AmberGL/include/AmberGL/SoftwareRenderer/RenderObject/RenderContext.h
@@ -2,7 +2,6 @@
 
 #include <cstdint>
 
-#include "AmberGL/SoftwareRenderer/Defines.h"
 #include "AmberGL/SoftwareRenderer/Programs/AProgram.h"
 #include "AmberGL/SoftwareRenderer/RenderObject/FrameBufferObject.h"
 
@@ -10,15 +9,22 @@ namespace AmberGL::SoftwareRenderer::RenderObject
 {
 	struct RenderContext
 	{
-		uint16_t ViewPortX = 0;
-		uint16_t ViewPortY = 0;
-		uint16_t ViewPortWidth = 0;
-		uint16_t ViewPortHeight = 0;
-		uint8_t State = 0;
-		uint8_t PolygonMode = AGL_FILL;
-		uint8_t CullFace = AGL_BACK;
-		uint8_t Samples = 0;
 		FrameBufferObject* FrameBufferObject;
-		Programs::AProgram* Program = nullptr;
+		Programs::AProgram* Program;
+
+		float LineWidth;
+		float PointSize;
+
+		uint16_t ViewPortX;
+		uint16_t ViewPortY;
+
+		uint16_t ViewPortWidth;
+		uint16_t ViewPortHeight;
+
+		uint16_t DepthFunc;
+		uint8_t State;
+		uint8_t PolygonMode;
+		uint8_t CullFace;
+		uint8_t Samples;
 	};
 }

--- a/Sources/AmberRenderer/AmberGL/include/AmberGL/SoftwareRenderer/TextureSampler.h
+++ b/Sources/AmberRenderer/AmberGL/include/AmberGL/SoftwareRenderer/TextureSampler.h
@@ -14,6 +14,9 @@ namespace AmberGL::SoftwareRenderer
 		~TextureSampler() = default;
 
 		static glm::vec4 Sample(const RenderObject::TextureObject* p_textureObject, const glm::vec2& p_texCoords, const std::array<glm::vec2, 2>& p_texCoordsDerivatives);
+
+		static void GenerateMipmaps(RenderObject::TextureObject* p_textureObject);
+
 		static uint8_t ComputeMipmapLevel(const RenderObject::TextureObject* p_textureObject, const glm::vec2& p_dfdx, const glm::vec2& p_dfdy);
 	private:
 		static float ApplyWrapMode(float p_coord, uint8_t p_wrapMode);

--- a/Sources/AmberRenderer/AmberGL/src/AmberGL/Geometry/Plane.cpp
+++ b/Sources/AmberRenderer/AmberGL/src/AmberGL/Geometry/Plane.cpp
@@ -1,0 +1,183 @@
+#include "AmberGL/Geometry/Plane.h"
+
+void AmberGL::Geometry::Plane::ClipTriangle(Polygon& p_polygon) const
+{
+	if (p_polygon.VerticesCount == 0)
+		return;
+
+	glm::vec4 insideVertices[MAX_POLY_COUNT];
+	glm::vec2 insideTexCoords[MAX_POLY_COUNT];
+	glm::vec3 insideNormals[MAX_POLY_COUNT];
+	float insideVaryings[MAX_POLY_COUNT][16];
+
+	uint8_t insideVerticesCount = 0;
+
+	glm::vec4 previousVertex = p_polygon.Vertices[p_polygon.VerticesCount - 1];
+	glm::vec2 previousTexCoords = p_polygon.TexCoords[p_polygon.VerticesCount - 1];
+	glm::vec3 previousNormal = p_polygon.Normals[p_polygon.VerticesCount - 1];
+	float* previousVarying = p_polygon.Varyings[p_polygon.VerticesCount - 1];
+
+	float previousPlaneDistance = SignedDistance(previousVertex);
+
+	for (int i = 0; i < p_polygon.VerticesCount; i++)
+	{
+		float currentPlaneDistance = SignedDistance(p_polygon.Vertices[i]);
+
+		if (previousPlaneDistance * currentPlaneDistance < 0.0f)
+		{
+			float t = previousPlaneDistance / (previousPlaneDistance - currentPlaneDistance);
+
+			insideVertices[insideVerticesCount] = {
+				glm::lerp(previousVertex.x, p_polygon.Vertices[i].x, t),
+				glm::lerp(previousVertex.y, p_polygon.Vertices[i].y, t),
+				glm::lerp(previousVertex.z, p_polygon.Vertices[i].z, t),
+				glm::lerp(previousVertex.w, p_polygon.Vertices[i].w, t)
+			};
+
+			insideTexCoords[insideVerticesCount] = {
+				glm::lerp(previousTexCoords.x, p_polygon.TexCoords[i].x, t),
+				glm::lerp(previousTexCoords.y, p_polygon.TexCoords[i].y, t)
+			};
+
+			insideNormals[insideVerticesCount] = {
+				glm::lerp(previousNormal.x, p_polygon.Normals[i].x, t),
+				glm::lerp(previousNormal.y, p_polygon.Normals[i].y, t),
+				glm::lerp(previousNormal.z, p_polygon.Normals[i].z, t)
+			};
+
+			for (int j = 0; j < p_polygon.VaryingsDataSize; j++)
+			{
+				insideVaryings[insideVerticesCount][j] = glm::lerp(previousVarying[j], p_polygon.Varyings[i][j], t);
+			}
+
+			insideVerticesCount++;
+		}
+
+		if (IsInFront(p_polygon.Vertices[i]))
+		{
+			insideVertices[insideVerticesCount] = p_polygon.Vertices[i];
+			insideTexCoords[insideVerticesCount] = p_polygon.TexCoords[i];
+			insideNormals[insideVerticesCount] = p_polygon.Normals[i];
+
+			for (int j = 0; j < p_polygon.VaryingsDataSize; j++)
+			{
+				insideVaryings[insideVerticesCount][j] = p_polygon.Varyings[i][j];
+			}
+
+			insideVerticesCount++;
+		}
+
+		previousVertex = p_polygon.Vertices[i];
+		previousTexCoords = p_polygon.TexCoords[i];
+		previousNormal = p_polygon.Normals[i];
+		previousVarying = p_polygon.Varyings[i];
+		previousPlaneDistance = currentPlaneDistance;
+	}
+
+	p_polygon.VerticesCount = insideVerticesCount;
+
+	for (int i = 0; i < insideVerticesCount; i++)
+	{
+		p_polygon.Vertices[i] = insideVertices[i];
+		p_polygon.TexCoords[i] = insideTexCoords[i];
+		p_polygon.Normals[i] = insideNormals[i];
+
+		for (int j = 0; j < p_polygon.VaryingsDataSize; j++)
+		{
+			p_polygon.Varyings[i][j] = insideVaryings[i][j];
+		}
+	}
+}
+
+void AmberGL::Geometry::Plane::ClipLine(Polygon& p_polygon) const
+{
+	if (p_polygon.VerticesCount != 2)
+		return;
+
+	float startPointPlaneDistance = SignedDistance(p_polygon.Vertices[0]);
+	float endPointPlaneDistance = SignedDistance(p_polygon.Vertices[1]);
+
+	if (startPointPlaneDistance < 0.0f && endPointPlaneDistance < 0.0f)
+	{
+		p_polygon.VerticesCount = 0;
+		return;
+	}
+
+	if (startPointPlaneDistance >= 0.0f && endPointPlaneDistance >= 0.0f)
+	{
+		return;
+	}
+
+	float t = startPointPlaneDistance / (startPointPlaneDistance - endPointPlaneDistance);
+
+	glm::vec4 intersectionPoint = 
+	{
+		glm::lerp(p_polygon.Vertices[0].x, p_polygon.Vertices[1].x, t),
+		glm::lerp(p_polygon.Vertices[0].y, p_polygon.Vertices[1].y, t),
+		glm::lerp(p_polygon.Vertices[0].z, p_polygon.Vertices[1].z, t),
+		glm::lerp(p_polygon.Vertices[0].w, p_polygon.Vertices[1].w, t)
+	};
+
+	glm::vec2 intersectionTexCoord = 
+	{
+		glm::lerp(p_polygon.TexCoords[0].x, p_polygon.TexCoords[1].x, t),
+		glm::lerp(p_polygon.TexCoords[0].y, p_polygon.TexCoords[1].y, t)
+	};
+
+	glm::vec3 intersectionNormal = 
+	{
+		glm::lerp(p_polygon.Normals[0].x, p_polygon.Normals[1].x, t),
+		glm::lerp(p_polygon.Normals[0].y, p_polygon.Normals[1].y, t),
+		glm::lerp(p_polygon.Normals[0].z, p_polygon.Normals[1].z, t)
+	};
+
+	float intersectionVaryings[16];
+	for (int j = 0; j < p_polygon.VaryingsDataSize; j++)
+	{
+		intersectionVaryings[j] = glm::lerp(p_polygon.Varyings[0][j], p_polygon.Varyings[1][j], t);
+	}
+
+	if (startPointPlaneDistance < 0.0f)
+	{
+		p_polygon.Vertices[0] = intersectionPoint;
+		p_polygon.TexCoords[0] = intersectionTexCoord;
+		p_polygon.Normals[0] = intersectionNormal;
+
+		for (int j = 0; j < p_polygon.VaryingsDataSize; j++)
+		{
+			p_polygon.Varyings[0][j] = intersectionVaryings[j];
+		}
+	}
+	else
+	{
+		p_polygon.Vertices[1] = intersectionPoint;
+		p_polygon.TexCoords[1] = intersectionTexCoord;
+		p_polygon.Normals[1] = intersectionNormal;
+
+		for (int j = 0; j < p_polygon.VaryingsDataSize; j++)
+		{
+			p_polygon.Varyings[1][j] = intersectionVaryings[j];
+		}
+	}
+}
+
+void AmberGL::Geometry::Plane::ClipPoint(Polygon& p_polygon) const
+{
+	if (p_polygon.VerticesCount != 1)
+		return;
+
+	if (SignedDistance(p_polygon.Vertices[0]) < 0.0f)
+	{
+		p_polygon.VerticesCount = 0;
+	}
+}
+
+float AmberGL::Geometry::Plane::SignedDistance(const glm::vec4& p_point) const
+{
+	return glm::dot(p_point, glm::vec4(Normal.x, Normal.y, Normal.z, Distance));
+}
+
+bool AmberGL::Geometry::Plane::IsInFront(const glm::vec4& p_point) const
+{
+	return SignedDistance(p_point) >= 0.0f;
+}

--- a/Sources/AmberRenderer/AmberGL/src/AmberGL/Geometry/Triangle.cpp
+++ b/Sources/AmberRenderer/AmberGL/src/AmberGL/Geometry/Triangle.cpp
@@ -55,3 +55,14 @@ float AmberGL::Geometry::Triangle::ComputeArea() const
 {
 	return ComputeEdge(Vertices[0], Vertices[1], Vertices[2]);
 }
+
+float AmberGL::Geometry::Triangle::ComputeMaxDepthSlope(const std::array<glm::vec4, 3>& p_vertices) const
+{
+	float dzdx = std::abs((p_vertices[1].z - p_vertices[0].z) / (p_vertices[1].x - p_vertices[0].x));
+	float dzdy = std::abs((p_vertices[2].z - p_vertices[0].z) / (p_vertices[2].y - p_vertices[0].y));
+
+	if (!std::isfinite(dzdx)) dzdx = 0.0f;
+	if (!std::isfinite(dzdy)) dzdy = 0.0f;
+
+	return std::max(dzdx, dzdy);
+}

--- a/Sources/AmberRenderer/AmberGL/src/AmberGL/SoftwareRenderer/Programs/AProgram.cpp
+++ b/Sources/AmberRenderer/AmberGL/src/AmberGL/SoftwareRenderer/Programs/AProgram.cpp
@@ -39,6 +39,21 @@ void AmberGL::SoftwareRenderer::Programs::AProgram::ProcessInterpolation(const g
 	}
 }
 
+void AmberGL::SoftwareRenderer::Programs::AProgram::ProcessPointInterpolation(float p_w0)
+{
+	m_interpolatedReciprocal = 1.0f / p_w0;
+
+	for (auto& [key, varData] : m_varyings)
+	{
+		int count = GetTypeCount(varData.Type);
+		for (int i = 0; i < count; i++)
+		{
+			float d0 = varData.Data[0][i];
+			varData.Interpolated[i] = d0 / p_w0;
+		}
+	}
+}
+
 glm::vec4 AmberGL::SoftwareRenderer::Programs::AProgram::ProcessFragment()
 {
 	return FragmentPass();


### PR DESCRIPTION
## Description
This PR introduces significant improvements to the line and point rasterization and adds depth functions to AmberGL.

### Major Changes

#### Line Rasterization Improvements
- **Implemented two rendering approaches:**
  - **Single-pixel lines (width = 1.0):** Uses Bresenham's algorithm for efficient, pixel-perfect line drawing
  - **Wide lines (width > 1.0):** Uses rectangular quad rendering that mimics OpenGL behavior
- Added perspective-correct interpolation for line rendering with proper depth handling
- Integrated MSAA support for both line types to improve anti-aliasing quality
- Added line clipping
- Explored Round Line rendering for learning purposes, actually used for triangle line rasterization 

#### Point Rasterization
- Introduced proper point rendering with configurable point size
- Added perspective-correct interpolation for points

#### Depth Function Support
- Added depth comparison modes:
  - `AGL_NEVER`, `AGL_LESS`, `AGL_EQUAL`, `AGL_LEQUAL`
  - `AGL_GREATER`, `AGL_NOTEQUAL`, `AGL_GEQUAL`, `AGL_ALWAYS`
- Added Triangles depth slope calculations

#### API Extensions
Extended AmberGL API with:
- `PointSize()` for configurable point rendering
- `LineWidth()` for adjustable line thickness  
- `DrawLine()` and `DrawPoint()` for direct rendering
- `DepthFunc()` for configurable depth testing

Depth testing now allows flexible comparison functions, enabling more complex rendering scenarios. The clipping system has been enhanced with specialized methods for different primitive types, improving correctness.

![image](https://github.com/user-attachments/assets/8685511b-3650-4b2a-86a0-ccbfdbb0fb6c)
![image](https://github.com/user-attachments/assets/5cd2b9dd-7212-40ae-aeef-ba6da3fac0c5)
![image](https://github.com/user-attachments/assets/47f3a1a1-00e0-4e01-b880-7d74820d6a45)
![image](https://github.com/user-attachments/assets/cb2c10d0-56cd-4c0a-9d74-00f013fedea5)

## Related Issues
Related to #10 